### PR TITLE
Fix page hidden under footer bug on small phones

### DIFF
--- a/src/styles/first-page.css
+++ b/src/styles/first-page.css
@@ -1,6 +1,7 @@
 .page-container {
   margin-top: -80px;
   background-color: inherit;
+  padding-bottom: 150px;
 }
 
 .first-page-container {


### PR DESCRIPTION
### What?

I fixed a display bug

### Why?

To allow users with iPhone 6 and SE type of screens view the full app especially when the users want to choose yearly plans.

### How?
- I added padding-bottom to page-container class of mobile displays